### PR TITLE
Fix: text-davinci-003 deprecation by switching to gpt-3.5-turbo-instruct model

### DIFF
--- a/supabase/functions/vector-search/index.ts
+++ b/supabase/functions/vector-search/index.ts
@@ -117,7 +117,7 @@ serve(async (req) => {
     `;
 
     const completionOptions: CreateCompletionRequest = {
-      model: "text-davinci-003",
+      model: "gpt-3.5-turbo-instruct",
       prompt,
       max_tokens: 512,
       temperature: 0,


### PR DESCRIPTION
## Problem
This repo uses `text-davinci-003` which will be [deprecated](https://platform.openai.com/docs/deprecations) on 2024-01-04.

## Solution
Switch to `gpt-3.5-turbo-instruct` which is API compatible.

## Other notes
We should update this repo to use the newer chat-based endpoints, but this PR acts as a stop-gap in the meantime.